### PR TITLE
Fix Structural Validity specs

### DIFF
--- a/Assertion/latest.md
+++ b/Assertion/latest.md
@@ -255,11 +255,11 @@ resource that returns a 200 OK.
 * `recipient`: must be an object
   * `type`: must be a valid type (currently, only "email" is supported)
   * `identity`: must be a **text**
-  * `hashed` (optional): must be **boolean**
+  * `hashed`: must be **boolean**
   * `salt` (optional): must be **text**
 * `image` (optional): must be a valid **URL** or **Data URL**.
 * `evidence` (optional): must be a valid **URL**
-* `issuedOn` (optional): must be a valid [**DateTime**](#datetime)
+* `issuedOn`: must be a valid [**DateTime**](#datetime)
 * `expires` (optional): must be a valid [**DateTime**](#datetime)
 * `verify`: must be an object
   * `type`: must be either "hosted" or "signed"


### PR DESCRIPTION
Remove "(optional)" statement from `recipient.hashed` and `.issuedOn`
for `BadgeAssertion` object since they're previous declared as
mandatory.
